### PR TITLE
Clean up `unanswered_first` query

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -29,7 +29,7 @@ class Question < ActiveRecord::Base
   scope :answered, -> { where('answered_at IS NOT NULL') }
 
   scope :unanswered_first, -> {
-    order('CASE WHEN answered_at IS NULL THEN 0 ELSE 1 END')
+    order('answered_at DESC NULLS FIRST, created_at ASC')
   }
 
   validates :opportunity, presence: true


### PR DESCRIPTION
Postgres has support for `NULLS FIRST`, which does what you want without a `CASE`.

It also allows you to order the questions after the nulls by 1) when they were answered and 2)  by when they were created. This way, unanswered requests that have been unanswered the longest appear first (to encourage triage) followed by answered requests ordered by most-recently-answered (to allow quick lookup of recently-answered questions.)

So this will result in something like:
- Question 5 (unanswered, submitted two hours ago)
- Question 7 (unanswered, submitted one hour ago)
- Question 9 (answered, submitted 5 minutes ago)
- Question 3 (answered, submitted 5 hours ago)
