### PR TITLE
Don't full text search attachments.

### DIFF
--- a/app/models/opportunity.rb
+++ b/app/models/opportunity.rb
@@ -98,7 +98,6 @@ class Opportunity < ActiveRecord::Base
     ],
     associated_against: {
       questions: [:question_text, :answer_text],
-      attachments: [:upload, :text_content],
       department: [:name]
     },
     using: {


### PR DESCRIPTION
The current search strategy does not handle large attachments well.
When an attachment is uploaded, we attempt to extract the text and store
it in the attachments table. That text is then used for full text search
when filtering in /opportunities. This triggers very expensive joins,
aggregations, and to_tsvector function calls which collectively consume
massive amounts of memory.

Re-enabling search of attachment text will require optimization, such as
creating a dedicated pg search index.