### PR TITLE
Update dependencies (Gemnasium auto-update dda227a5be2de236488509e6208c7fdfe8fb63a7)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,10 +85,10 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bourbon (4.2.7)
+    bourbon (4.3.2)
       sass (~> 3.4)
       thor (~> 0.19)
-    brakeman (3.4.1)
+    brakeman (3.5.0)
     builder (3.2.3)
     capybara (2.12.0)
       addressable
@@ -193,7 +193,7 @@ GEM
     htmlentities (4.3.4)
     http_parser.rb (0.6.0)
     i18n (0.8.0)
-    i18n-tasks (0.9.10)
+    i18n-tasks (0.9.12)
       activesupport (>= 4.0.2)
       ast (>= 2.1.0)
       easy_translate (>= 0.5.0)
@@ -227,7 +227,7 @@ GEM
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
     mime-types (1.25.1)
-    mini_magick (4.6.0)
+    mini_magick (4.6.1)
     mini_portile2 (2.1.0)
     minitest (5.10.1)
     momentjs-rails (2.17.1)
@@ -237,7 +237,7 @@ GEM
       sass (>= 3.3)
       thor (~> 0.19)
     nenv (0.3.0)
-    newrelic_rpm (3.18.0.329)
+    newrelic_rpm (3.18.1.330)
     nokogiri (1.7.0.1)
       mini_portile2 (~> 2.1.0)
     normalize-rails (3.0.3)
@@ -245,7 +245,7 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
-    parser (2.3.3.1)
+    parser (2.4.0.0)
       ast (~> 2.2)
     pg (0.19.0)
     pg_search (2.0.1)
@@ -415,7 +415,7 @@ GEM
     thread (0.2.2)
     thread_safe (0.3.5)
     tilt (2.0.6)
-    tins (1.13.0)
+    tins (1.13.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.4)
@@ -511,4 +511,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.14.3
+   1.14.4


### PR DESCRIPTION
Update dependencies:
newrelic_rpm: 3.18.0.329 => 3.18.1.330
mini_magick: 4.6.0 => 4.6.1
bourbon: 4.2.7 => 4.3.2
tins: 1.13.0 => 1.13.2
brakeman: 3.4.1 => 3.5.0
parser: 2.3.3.1 => 2.4.0.0
i18n-tasks: 0.9.10 => 0.9.12